### PR TITLE
Linux64: mozconfig: switch march target to `x86-64-v3` from `native`

### DIFF
--- a/MozConfigs/Linux64/mozconfig
+++ b/MozConfigs/Linux64/mozconfig
@@ -43,7 +43,7 @@ mk_add_options MOZ_SERVICES_HEALTHREPORT=0
 mk_add_options MOZ_TELEMETRY_REPORTING=0
 
 export RUSTFLAGS="-C opt-level=3 -C target-cpu=native -C codegen-units=1 -Cpanic=abort -Cforce-frame-pointers=no -Cllvm-args=--inline-threshold=1000 -Cllvm-args=-vectorize-loops -Cllvm-args=-vectorize-slp"
-export CFLAGS="-O3 -march=native -mtune=native -mavx2 -maes -msse4.2 -fno-semantic-interposition -fomit-frame-pointer -fdata-sections -ffunction-sections -fno-plt -funroll-loops $CFLAGS"
+export CFLAGS="-O3 -march=x86-64-v3 -mavx2 -maes -msse4.2 -fno-semantic-interposition -fomit-frame-pointer -fdata-sections -ffunction-sections -fno-plt -funroll-loops $CFLAGS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,-O3 -Wl,--gc-sections -Wl,-z,now -Wl,-z,relro -Wl,--icf=all $LDFLAGS"
 


### PR DESCRIPTION
-march=native -mtune=native is a really bad idea if you want to distribute binaries that run multiple machines

fixes #10 